### PR TITLE
Fix null due date

### DIFF
--- a/src/taskParser.ts
+++ b/src/taskParser.ts
@@ -467,7 +467,7 @@ export class TaskParser {
         }
 
         // If any has a invvalid date, return false as you can't compare
-        else if (lineTaskDue.toString() === "Invalid Date" || todoistTaskDue.toString() === "Invalid Date") {
+        else if (lineTaskDue.toString() === "Invalid Date" || (todoistTaskDue && todoistTaskDue.toString() === "Invalid Date")) {
             return false;
         }
         // If everything above is false, than return true because the dates are different


### PR DESCRIPTION
Fix bug when the due date of the todoist task is NULL (not set).

For me, this happen each time I create a task in this order : 
- write "- [ ] blablabla #tdsync"
- wait for the task to sync (the id is added)
- Add the due date after