### PR TITLE
Based on #31 - Added support for deadline with {{MM-DD}}

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Create, edit, and delete tasks from within Obsidian.md to your Todoist.
 
 > [!CAUTION]
-> In early April 2025, this plugin was no longer working due to changes on the Todoist API. As a lot changed, I had to rewrite 80% of the plugin, so I don't consider this plugin as stable as it was before v0.5.0—any version before this will not work. [Check this comment for more details](https://github.com/eudennis/ultimate-todoist-sync-for-obsidian-experiment/issues/24#issuecomment-2817456870). Feel free to open bug reports.
+> In early April 2025, this plugin was no longer working due to changes on the Todoist API. [Check this comment for more details](https://github.com/eudennis/ultimate-todoist-sync-for-obsidian-experiment/issues/24#issuecomment-2817456870). Feel free to open bug reports.
 
 > [!WARNING]
-> This is a fork from the [Ultimate Todoist Sync plugin for Obsidian](https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian). I'm still working on fixing some things, but the main feature should be working. I'm considering this feature a beta. Feel free to contribute.
+> This is a fork from the [Ultimate Todoist Sync plugin for Obsidian](https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian). I consider this as a beta, but I have been using for quite some time without issues. Feel free to contribute opening bug reports if you find anything.
 >
 > _Some features works only Todoist -> Obsidian, others by-directional. Find more details on the feature table below._
 
@@ -38,6 +38,7 @@ Create, edit, and delete tasks from within Obsidian.md to your Todoist.
 | Task notes [2]           | 🔜                       | ✅                       |
 | Optional app link        | ✅                       | ✅                       |
 | Assign project to task   | ✅                       | 🔜                       |
+| Manage Deadline Date     | ✅                       | 🔜                       |
 
 -   [1] Task priority only support one-way synchronization
 -   [2] Task notes/comments only support one-way synchronization from Todoist to Obsidian.
@@ -47,7 +48,7 @@ Create, edit, and delete tasks from within Obsidian.md to your Todoist.
 ## Installation
 
 > [!WARNING]
-> The plugin will require the _Todoist API token_, which can be found on your `Settings > Integrations > Developer` ([direct link here](https://app.todoist.com/app/settings/integrations/developer))
+> The plugin will require the _Todoist API token_, which can be found on your `Settings > Integrations > Developer` ([direct link here](https://app.todoist.com/app/settings/integrations/developer)). Note that some features will work for [Todoist paid users](https://www.todoist.com/pricing).
 
 ### From within Obsidian
 
@@ -99,6 +100,7 @@ Create, edit, and delete tasks from within Obsidian.md to your Todoist.
 | ///<section_name>    | This adds the task to a section with <section_name>                                                                                    | `- [ ] task ///section_name`[7]                |
 | #project #tag        | First hashtag assign to a project with the same name                                                                                   | `-[ ] task #project #tag1 #tag2` [8]           |
 | %%[p::ProjectName]%% | Assign task to project with hidden field                                                                                               | `%%[p::ProjectName]%%` [9]                     |
+| {{YYYY-MM-DD}}       | Assign a deadline date to a task                                                                                                       | `{{YYYY-MM-DD}}` [10]                          |
 
 <details>
 <summary>Usage footnotes</summary>
@@ -112,6 +114,7 @@ Create, edit, and delete tasks from within Obsidian.md to your Todoist.
 -   [7] If the section if removed from the task content, it won't update in Todoist (yet)
 -   [8] First tag will be used for project, but will also create a tag with the same name.
 -   [9] Project name is case-sensitive.
+-   [10] It supports YY-MM-DD, and if you use MM-DD default to the current YY
 
 </details>
 

--- a/attachment/CHANGELOG.md
+++ b/attachment/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+## 2025-05-24
+
+### 0.5.6
+
+-   Added support to deadline dates
+
 ## 2025-05-10
 
 ### 0.5.5

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "another-simple-todoist-sync",
 	"name": "Another Simple Todoist Sync",
-	"version": "0.5.5",
+	"version": "0.5.6-beta",
 	"minAppVersion": "1.0.0",
 	"description": "Sync tasks with Todoist from within your notes.",
 	"author": "eudennis",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "another-simple-todoist-sync",
   "name": "Another Simple Todoist Sync",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "minAppVersion": "1.0.0",
   "description": "Sync tasks with Todoist from within your notes.",
   "author": "eudennis",

--- a/src/cacheOperation.ts
+++ b/src/cacheOperation.ts
@@ -36,6 +36,11 @@ export interface Task {
 	duration_unit?: "minute" | "day";
 	isCompleted?: boolean;
 	path?: string;
+	deadline_date?: string;
+	deadline?: {
+		date: string;
+		lang: string;
+	}
 }
 
 interface Project {
@@ -727,7 +732,7 @@ export class CacheOperation {
 		this.plugin.settings.fileMetadata = newFileMetadataRemovingOldTasks;
 
 		if (this.plugin.settings?.defaultProjectId?.length === 10) {
-			console.log("defaultProjectId is old, need to select a new one");
+			console.warn("defaultProjectId is old, need to select a new one");
 		}
 	}
 }

--- a/src/todoistAPI.ts
+++ b/src/todoistAPI.ts
@@ -51,6 +51,7 @@ export class TodoistNewAPI {
 		duration_unit,
 		section_id,
 		path,
+		deadline_date,
 	}: {
 		project_id: string;
 		content: string;
@@ -64,6 +65,7 @@ export class TodoistNewAPI {
 		duration_unit?: string;
 		section_id?: string;
 		path?: string;
+		deadline_date?: string;
 	}) {
 		try {
 			const taskData: {
@@ -79,6 +81,7 @@ export class TodoistNewAPI {
 				due_datetime?: string;
 				duration?: number;
 				duration_unit?: string;
+				deadline_date?: string;
 			} = {
 				content,
 				description,
@@ -91,6 +94,7 @@ export class TodoistNewAPI {
 				due_datetime,
 				duration,
 				duration_unit,
+				deadline_date
 			};
 
 			if (taskData.section_id === "") {
@@ -288,6 +292,7 @@ export class TodoistNewAPI {
 			duration?: number;
 			duration_unit?: string;
 			section_id?: string;
+			deadline_date?: string;
 		},
 	) {
 		const token = this.plugin.settings.todoistAPIToken;
@@ -306,7 +311,8 @@ export class TodoistNewAPI {
 			!updates.parent_id &&
 			!updates.priority &&
 			!updates.duration &&
-			!updates.section_id
+			!updates.section_id &&
+			!updates.deadline_date
 		) {
 			throw new Error("At least one update is required");
 		}
@@ -324,6 +330,7 @@ export class TodoistNewAPI {
 				due_datetime?: string;
 				duration?: number;
 				duration_unit?: string;
+				deadline_date?: string;
 			} = {};
 
 			// Handle content updates
@@ -354,6 +361,9 @@ export class TodoistNewAPI {
 			// Handle section ID updates
 			if (updates.section_id) {
 				taskData.section_id = updates.section_id;
+			}
+			if(updates.deadline_date) {
+				taskData.deadline_date = updates.deadline_date;
 			}
 
 			// Handle due date and time


### PR DESCRIPTION
- Adds support for the keyword {{MM-DD}} to implement Todoist "new feature" deadlines.

Considerations:
- It supports YYYY-MM-DD and YYYY-MM-DD
- It doesn't support Todoist sync back to Obsidian (if you update the deadline on Todoist, it won't update on Obsidian), because it seems that those changes are no published to Todoist events